### PR TITLE
SSEMR-238 Get actual EAC sessions dates and not the encounter dates

### DIFF
--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/DateExtendedEACDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/DateExtendedEACDataEvaluator.java
@@ -35,9 +35,9 @@ public class DateExtendedEACDataEvaluator implements PersonDataEvaluator {
 	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context)
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
-
+		
 		String qry = "SELECT client_id, DATE_FORMAT(MID(MAX(CONCAT(encounter_datetime, date_of_extra_session)), 20), '%Y-%m-%d') AS lastEacExtendedDate "
-				+ "FROM ssemr_etl.ssemr_flat_encounter_high_viral_load WHERE date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
+		        + "FROM ssemr_etl.ssemr_flat_encounter_high_viral_load WHERE date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/DateExtendedEACDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/DateExtendedEACDataEvaluator.java
@@ -35,12 +35,9 @@ public class DateExtendedEACDataEvaluator implements PersonDataEvaluator {
 	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context)
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
-		
-		String qry = "SELECT lr.client_id, DATE_FORMAT(CONCAT(MID(MAX(CONCAT(fp.encounter_datetime, lr.last_vl_date_repeat)), 20)), '%Y-%m-%d')  "
-		        + " as vl_repeat_date FROM ssemr_etl.ssemr_flat_encounter_vl_laboratory_request lr "
-		        + " left join ssemr_etl.ssemr_flat_encounter_hiv_care_follow_up fp on lr.client_id = fp.client_id "
-		        + " where fp.encounter_datetime <= DATE(:endDate) and lr.last_vl_date_repeat is not null "
-		        + " group by fp.client_id, lr.last_vl_date_repeat;";
+
+		String qry = "SELECT client_id, DATE_FORMAT(MID(MAX(CONCAT(encounter_datetime, date_of_extra_session)), 20), '%Y-%m-%d') AS lastEacExtendedDate "
+				+ "FROM ssemr_etl.ssemr_flat_encounter_high_viral_load WHERE date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/LastEAC1DateDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/LastEAC1DateDataEvaluator.java
@@ -37,10 +37,8 @@ public class LastEAC1DateDataEvaluator implements PersonDataEvaluator {
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
 		
-		String qry = "SELECT client_id, DATE_FORMAT(max(encounter_datetime), '%Y-%m-%d')  as lastEac1Date FROM ssemr_etl.ssemr_flat_encounter_high_viral_load "
-		        + " WHERE  date(encounter_datetime) <= date(:endDate) "
-		        + " AND eac_session = 'First EAC Session' "
-		        + " GROUP BY client_id;";
+		String qry = "SELECT client_id, DATE_FORMAT(MID(MAX(CONCAT(encounter_datetime, adherence_date)), 20), '%Y-%m-%d') AS lastEac1Date "
+		        + "FROM ssemr_etl.ssemr_flat_encounter_high_viral_load WHERE date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/LastEAC2DateDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/LastEAC2DateDataEvaluator.java
@@ -36,10 +36,8 @@ public class LastEAC2DateDataEvaluator implements PersonDataEvaluator {
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
 		
-		String qry = "SELECT client_id, DATE_FORMAT(max(encounter_datetime), '%Y-%m-%d') as lastEac2Date FROM ssemr_etl.ssemr_flat_encounter_high_viral_load "
-		        + " WHERE  date(encounter_datetime) <= date(:endDate) "
-		        + " AND eac_session = 'Second EAC Session' "
-		        + " GROUP BY client_id;";
+		String qry = "SELECT client_id, DATE_FORMAT(MID(MAX(CONCAT(encounter_datetime, second_eac_session_date)), 20), '%Y-%m-%d') AS lastEac2Date "
+		        + "FROM ssemr_etl.ssemr_flat_encounter_high_viral_load WHERE date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/LastEAC3DateDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/LastEAC3DateDataEvaluator.java
@@ -36,10 +36,8 @@ public class LastEAC3DateDataEvaluator implements PersonDataEvaluator {
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
 		
-		String qry = "SELECT client_id, DATE_FORMAT(max(encounter_datetime), '%Y-%m-%d') as lastEac3Date FROM ssemr_etl.ssemr_flat_encounter_high_viral_load "
-		        + " WHERE  date(encounter_datetime) <= date(:endDate) "
-		        + " AND eac_session = 'Third EAC Session' "
-		        + " GROUP BY client_id;";
+		String qry = "SELECT client_id, DATE_FORMAT(MID(MAX(CONCAT(encounter_datetime, third_eac_session_date)), 20), '%Y-%m-%d') AS lastEac3Date "
+		        + "FROM ssemr_etl.ssemr_flat_encounter_high_viral_load WHERE date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);


### PR DESCRIPTION
@moshonk please help review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved SQL queries for evaluating last EAC dates, enhancing data accuracy.
  
- **New Features**
	- Enhanced data retrieval logic for last EAC dates by utilizing substring extraction methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->