### PR TITLE
(fix) Look for Art Start Date from multiple tables, and Get the correct VL Sample collected Date

### DIFF
--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/ArtStartDateDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/ArtStartDateDataEvaluator.java
@@ -35,9 +35,20 @@ public class ArtStartDateDataEvaluator implements PersonDataEvaluator {
 	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context)
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
-		
+
 		String qry = "SELECT client_id, DATE_FORMAT(MID(MAX(CONCAT(encounter_datetime, art_start_date)), 20), '%d-%m-%Y') AS max_art_start_date "
-		        + "FROM ssemr_etl.ssemr_flat_encounter_personal_family_tx_history where date(encounter_datetime) <= date(:endDate) GROUP BY client_id";
+				+ "FROM ( "
+				+ "    SELECT client_id, encounter_datetime, art_start_date "
+				+ "    FROM ssemr_etl.ssemr_flat_encounter_personal_family_tx_history "
+				+ "    WHERE date(encounter_datetime) <= date(:endDate) "
+				+ "    UNION ALL "
+				+ "    SELECT client_id, encounter_datetime, art_start_date "
+				+ "    FROM ssemr_etl.ssemr_flat_encounter_adult_and_adolescent_intake "
+				+ "    WHERE date(encounter_datetime) <= date(:endDate) "
+				+ "    UNION ALL "
+				+ "    SELECT client_id, encounter_datetime, art_start_date "
+				+ "    FROM ssemr_etl.ssemr_flat_encounter_pediatric_intake_report "
+				+ "    WHERE date(encounter_datetime) <= date(:endDate) " + ") combined_data " + "GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/DateVLSampleCollectedDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/DateVLSampleCollectedDataEvaluator.java
@@ -35,8 +35,11 @@ public class DateVLSampleCollectedDataEvaluator implements PersonDataEvaluator {
 	public EvaluatedPersonData evaluate(PersonDataDefinition definition, EvaluationContext context)
 	        throws EvaluationException {
 		EvaluatedPersonData c = new EvaluatedPersonData(definition, context);
-		
-		String qry = "SELECT client_id, DATE_FORMAT(max(date_vl_sample_collected), '%d-%m-%Y') as documented_date FROM ssemr_etl.ssemr_flat_encounter_hiv_care_follow_up where DATE(encounter_datetime) <= :endDate group by client_id";
+
+		String qry = "SELECT client_id, "
+				+ "DATE_FORMAT(MAX(CASE WHEN date_vl_sample_collected IS NOT NULL THEN date_vl_sample_collected ELSE NULL END), '%d-%m-%Y') AS documented_date "
+				+ "FROM ssemr_etl.ssemr_flat_encounter_hiv_care_follow_up " + "WHERE DATE(encounter_datetime) <= :endDate "
+				+ "GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);


### PR DESCRIPTION
…Sample collected Date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of ART start date reporting by aggregating data from multiple sources.
  - Enhanced viral load sample collection date reporting to better handle and exclude missing dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->