### PR TITLE
SSEMR-655 fix(reporting): Fetch Latest TB Status and Screened for TB

### DIFF
--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/TBScreeningDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/TBScreeningDataEvaluator.java
@@ -33,7 +33,7 @@ public class TBScreeningDataEvaluator implements PersonDataEvaluator {
 		        + "THEN 'YES' " + "WHEN MID(MAX(CONCAT(encounter_datetime, on_tb_treatment)), 20) = 'Yes' THEN 'NO' "
 		        + "WHEN MID(MAX(CONCAT(encounter_datetime, on_tb_treatment)), 20) IS NULL THEN 'N/A' "
 		        + "END AS tb_screening " + "FROM ssemr_etl.ssemr_flat_encounter_hiv_care_follow_up "
-		        + "WHERE encounter_datetime BETWEEN :startDate AND :endDate " + "GROUP BY client_id";
+		        + "WHERE encounter_datetime <= :endDate " + "GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/TBStatusDataEvaluator.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/data/evaluator/TBStatusDataEvaluator.java
@@ -34,7 +34,7 @@ public class TBStatusDataEvaluator implements PersonDataEvaluator {
 		        + "    WHEN 'Pr TB - Presumptive TB' THEN 'Presumptive TB' "
 		        + "    WHEN 'ND - TB Screening not done' THEN 'Not done' " + "    ELSE 'N/A' " + "  END "
 		        + "END AS tb_status " + "FROM ssemr_etl.ssemr_flat_encounter_hiv_care_follow_up "
-		        + "WHERE encounter_datetime BETWEEN :startDate AND :endDate " + "GROUP BY client_id";
+		        + "WHERE encounter_datetime <= :endDate " + "GROUP BY client_id";
 		
 		SqlQueryBuilder queryBuilder = new SqlQueryBuilder();
 		queryBuilder.append(qry);

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/datasets/AllClientsDatasetDefinition.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/datasets/AllClientsDatasetDefinition.java
@@ -127,7 +127,6 @@ public class AllClientsDatasetDefinition extends SsemrBaseDataSet {
 		tbScreeningDataDefinition.addParameter(new Parameter("endDate", "End Date", Date.class));
 		
 		TBStatusDataDefinition tbStatusDataDefinition = new TBStatusDataDefinition();
-		tbStatusDataDefinition.addParameter(new Parameter("startDate", "Start Date", Date.class));
 		tbStatusDataDefinition.addParameter(new Parameter("endDate", "End Date", Date.class));
 		
 		EDDDataDefinition eddDataDefinition = new EDDDataDefinition();
@@ -171,7 +170,7 @@ public class AllClientsDatasetDefinition extends SsemrBaseDataSet {
 		dsd.addColumn("Date of ART initiation", artStartDateDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Client Represented", clientRepresentedDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Screened for TB", tbScreeningDataDefinition, "endDate=${endDate}");
-		dsd.addColumn("TB Status", tbStatusDataDefinition, "startDate=${startDate},endDate=${endDate}");
+		dsd.addColumn("TB Status", tbStatusDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Pregnant", patientPregnantDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("EDD", eddDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Breastfeeding", patientBreastfeedingDateDataDefinition, "endDate=${endDate}");

--- a/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/datasets/TbScreeningDatasetDefinition.java
+++ b/api/src/main/java/org/openmrs/module/ssemrreports/reporting/library/datasets/TbScreeningDatasetDefinition.java
@@ -90,7 +90,6 @@ public class TbScreeningDatasetDefinition extends SsemrBaseDataSet {
 		breastfeedingDataDefinition.addParameter(new Parameter("endDate", "End Date", Date.class));
 		
 		TBStatusDataDefinition tbStatusDataDefinition = new TBStatusDataDefinition();
-		tbStatusDataDefinition.addParameter(new Parameter("startDate", "Start Date", Date.class));
 		tbStatusDataDefinition.addParameter(new Parameter("endDate", "End Date", Date.class));
 		
 		DateScreenedForTBDataDefinition dateScreenedForTBDataDefinition = new DateScreenedForTBDataDefinition();
@@ -108,7 +107,7 @@ public class TbScreeningDatasetDefinition extends SsemrBaseDataSet {
 		dsd.addColumn("Pregnant", pregnantDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Breastfeeding", breastfeedingDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Date of ART initiation", etlArtStartDateDataDefinition, "endDate=${endDate}");
-		dsd.addColumn("TB Status", tbStatusDataDefinition, "startDate=${startDate},endDate=${endDate}");
+		dsd.addColumn("TB Status", tbStatusDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Date Screened for TB", dateScreenedForTBDataDefinition, "endDate=${endDate}");
 		dsd.addColumn("Payam", personPayamAddress(), "", new CalculationResultConverter());
 		dsd.addColumn("Boma", personBomaAddress(), "", new CalculationResultConverter());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Viral Load report now shows a unified “Final Status” per client, including Pending Result, BDL, or the latest numeric value.

- Improvements
  - Viral Load calculations use the latest available encounters to improve accuracy.
  - TB Screening and TB Status reports now include all records up to the selected end date, ensuring the most recent status is reflected.

- Chores
  - Removed the Start Date input where no longer applicable (TB Status/TB Screening datasets), simplifying report parameter selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->